### PR TITLE
Fix mod update check error

### DIFF
--- a/info.json
+++ b/info.json
@@ -6,5 +6,5 @@
 	"EntryMethod": "ImprovedJobOverview.ImprovedJobOverview.Load",
 	"ManagerVersion": "0.27.3",
 	"AssemblyName": "ImprovedJobOverview.dll",
-	"Repository": "https://github.com/MisfitMaid/dv-improved-job-overview/blob/mistress/repository.json"
+	"Repository": "https://raw.githubusercontent.com/MisfitMaid/dv-improved-job-overview/mistress/repository.json"
 }


### PR DESCRIPTION
Fix UMM being unable to check for updates to this mod due to a misconfigured repository JSON link and the resulting error message `Error checking updates on 'https://github.com/MisfitMaid/dv-improved-job-overview/blob/mistress/repository.json' for [Improved Job Overview].`.